### PR TITLE
Add openai compatible inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ company has juniors.
 
 **Any engine.** Claude Code, Codex and Gemini CLI run as real agents that
 use tools and touch files. Gemini, Grok, Kimi, Llama, DeepSeek, Mistral,
-Groq, OpenRouter and Ollama connect as chat engines. OpenRouter has a
+Groq, OpenRouter and Ollama connect as chat engines. A custom
+OpenAI-compatible host takes a base URL and one or more keys. OpenRouter has a
 proper browser sign-in; the rest take a key or ride along with a CLI you
 already signed in to.
 
@@ -129,6 +130,7 @@ You need one of these before an agent can reply. Any of them works.
 | Gemini CLI | `npm i -g @google/gemini-cli`, then a Google sign-in or a Gemini key | yes |
 | OpenRouter | Sign in from Settings, in your browser | no |
 | Gemini, Grok, Kimi, Llama, DeepSeek, Mistral, Groq | Paste a key in Settings | no |
+| Custom (OpenAI-compatible) | Paste a base URL and key(s) in Settings | no |
 | Ollama | Run it; Bloks finds it on this machine | no |
 
 The engines marked "runs tools" can execute commands and read files. The

--- a/server/agent-cli.ts
+++ b/server/agent-cli.ts
@@ -120,6 +120,7 @@ export const RULES: Rule[] = [
 export const NEVER = [
   "/api/config",
   "/api/providers",
+  "/api/custom-endpoints",
   "/api/instances",
   "/api/pair",
   "/api/mcp-servers",

--- a/server/config.ts
+++ b/server/config.ts
@@ -14,13 +14,33 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { InstanceConfigMap } from "./contracts.ts";
-import { PROVIDER_SPECS, specFor } from "./providers.ts";
+import { CUSTOM_SPEC, PROVIDER_SPECS, specFor } from "./providers.ts";
 
 /** One connected engine: the credential, plus an override for people
  * pointing at a proxy or a self-hosted endpoint. */
 export interface ProviderConfig {
   key?: string;
   url?: string;
+}
+
+/** One credential on a user-added OpenAI-compatible host. Several can
+ * share a URL; the active one is what the live instance sends. */
+export interface CustomKey {
+  id: string;
+  /** Optional name so two keys on one host can be told apart. */
+  label?: string;
+  key: string;
+}
+
+/** A third-party host that speaks OpenAI's /v1 shape. Secrets stay in
+ * this file with the rest of the keys. */
+export interface CustomEndpoint {
+  id: string;
+  name: string;
+  url: string;
+  keys: CustomKey[];
+  /** Which key the instance uses. Missing means the first key. */
+  activeKeyId?: string;
 }
 
 export interface AppConfig {
@@ -47,6 +67,9 @@ export interface AppConfig {
    * Off until somebody sets one: a global hotkey that arrives
    * uninvited will collide with whatever they already use. */
   shortcuts?: { quickAsk?: string | null };
+  /** User-added OpenAI-compatible hosts. Same file as the other keys
+   * because this is already the secrets file. */
+  custom?: CustomEndpoint[];
   /** User-registered MCP servers, attachable per agent. Headers and
    * commands live here because this file is already the secrets file. */
   mcpServers?: Array<{
@@ -205,6 +228,9 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   if (Array.isArray((patch as Record<string, unknown>).mcpServers)) {
     disk.mcpServers = (patch as Record<string, unknown>).mcpServers;
   }
+  if (Array.isArray((patch as Record<string, unknown>).custom)) {
+    disk.custom = (patch as Record<string, unknown>).custom;
+  }
   if (typeof (patch as Record<string, unknown>).setupDoneAt === "number") {
     disk.setupDoneAt = (patch as Record<string, unknown>).setupDoneAt;
   }
@@ -267,6 +293,19 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
       ...(cfg.providers?.[kind]?.url ? { config: { url: cfg.providers[kind].url } } : {}),
     };
   }
+  // One instance per custom host. Several keys can sit on that host;
+  // only the active one is injected, so rotating a key is a settings
+  // change rather than a new engine in the picker.
+  for (const endpoint of cfg.custom ?? []) {
+    const cred = activeCustomKey(endpoint);
+    if (!endpoint.url || !cred?.key) continue;
+    map[customInstanceId(endpoint.id)] = {
+      driver: CUSTOM_SPEC.kind,
+      displayName: endpoint.name,
+      config: { url: endpoint.url },
+      environment: { [envVarFor(CUSTOM_SPEC.kind)]: cred.key },
+    };
+  }
   for (const entry of Object.values(map)) {
     entry.environment = {
       ...cfg.secrets,
@@ -281,4 +320,16 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     };
   }
   return map;
+}
+
+export function customInstanceId(endpointId: string): string {
+  return `custom_${endpointId}`;
+}
+
+export function activeCustomKey(endpoint: CustomEndpoint): CustomKey | undefined {
+  if (endpoint.activeKeyId) {
+    const named = endpoint.keys.find((k) => k.id === endpoint.activeKeyId && k.key);
+    if (named) return named;
+  }
+  return endpoint.keys.find((k) => k.key);
 }

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -3,7 +3,7 @@
 // the catalog in providers.ts, so adding another lab is a spec rather
 // than a driver.
 import type { AnyProviderDriver } from "../contracts.ts";
-import { PROVIDER_SPECS } from "../providers.ts";
+import { CUSTOM_SPEC, PROVIDER_SPECS } from "../providers.ts";
 import { acpDriver, ACP_SPECS } from "./acp.ts";
 import { AntigravityDriver } from "./antigravity.ts";
 import { BoxAgentDriver } from "./boxagent.ts";
@@ -13,6 +13,7 @@ import { openAiCompatDriver } from "./openai-compat.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   ...PROVIDER_SPECS.map(openAiCompatDriver),
+  openAiCompatDriver(CUSTOM_SPEC),
   ...ACP_SPECS.map(acpDriver),
   AntigravityDriver,
   ClaudeDriver,

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,7 +24,9 @@ import * as composio from "./composio.ts";
 import {
   APP_VERSION,
   DATA_DIR,
+  activeCustomKey,
   connectedProviders,
+  customInstanceId,
   disconnectProvider,
   ensureDirs,
   instanceConfigs,
@@ -34,9 +36,11 @@ import {
   EVENTS_DIR,
   NATIVE_DIR,
   type AppConfig,
+  type CustomEndpoint,
+  type CustomKey,
 } from "./config.ts";
 import { RelayLink, relayDeviceFor } from "./relay-link.ts";
-import { CLI_PROVIDERS, PROVIDER_SPECS, specFor } from "./providers.ts";
+import { CLI_PROVIDERS, PROVIDER_SPECS, normalizeCompatUrl, specFor } from "./providers.ts";
 import { callbackPage, finishOAuth, startOAuth, supportsOAuth } from "./oauth.ts";
 import type { RuntimeEvent } from "./contracts.ts";
 
@@ -65,13 +69,17 @@ import {
   clamp,
   clampList,
   MAX_BODY_BYTES,
+  MAX_CUSTOM_ENDPOINTS,
+  MAX_CUSTOM_KEYS,
   MAX_DESCRIPTION_CHARS,
+  MAX_KEY_CHARS,
   MAX_MESSAGE_CHARS,
   MAX_NAME_CHARS,
   MAX_SKILL_CHARS,
   MAX_SKILLS,
   MAX_SSE_CLIENTS,
   MAX_TITLE_CHARS,
+  MAX_URL_CHARS,
 } from "./limits.ts";
 import {
   describeAgentFile,
@@ -2910,6 +2918,46 @@ async function connectProvider(kind: string, key: string, endpoint = "") {
   broadcast({ kind: "providers", ...(await providerCatalog()) });
 }
 
+/** What Settings renders for user-added hosts: names, URLs, key labels.
+ * Never the keys themselves. */
+function customCatalog() {
+  return {
+    endpoints: (cfg.custom ?? []).map((endpoint) => {
+      const active = activeCustomKey(endpoint);
+      return {
+        id: endpoint.id,
+        name: endpoint.name,
+        url: endpoint.url,
+        instanceId: customInstanceId(endpoint.id),
+        activeKeyId: active?.id ?? null,
+        keys: endpoint.keys.map((cred) => ({
+          id: cred.id,
+          label: cred.label ?? "",
+          active: cred.id === active?.id,
+        })),
+      };
+    }),
+  };
+}
+
+async function persistCustom(next: CustomEndpoint[]) {
+  saveConfig({ custom: next } as Partial<AppConfig>);
+  Object.assign(cfg, loadConfig());
+  // loadConfig re-reads the file; keep the in-memory list aligned with
+  // what we just wrote so a follow-up in this request sees it.
+  cfg.custom = next;
+  await reloadProviders();
+  broadcast({ kind: "providers", ...(await providerCatalog()) });
+}
+
+function parseCustomKey(body: Record<string, unknown>): { key?: string; label?: string; error?: string } {
+  const key = typeof body.key === "string" ? body.key.trim() : "";
+  const label = clamp(body.label, MAX_NAME_CHARS);
+  if (!key) return { error: "a key is required" };
+  if (key.length > MAX_KEY_CHARS) return { error: "that key is too long" };
+  return { key, ...(label ? { label } : {}) };
+}
+
 // ── request and response helpers ──────────────────────────────────────
 function json(res: ServerResponse, status: number, body: unknown) {
   const data = JSON.stringify(body);
@@ -4511,6 +4559,9 @@ const server = createServer(async (req, res) => {
     if (m && method === "POST") {
       const spec = specFor(m[1]);
       if (!spec) return json(res, 404, { error: "no such provider" });
+      if (spec.kind === "custom") {
+        return json(res, 400, { error: "add a custom endpoint from Settings" });
+      }
       if (spec.auth === "cli") return json(res, 400, { error: `${spec.name} signs in through its own CLI` });
       const body = await readBody(req);
       const key = String(body.key ?? "").trim();
@@ -4536,6 +4587,89 @@ const server = createServer(async (req, res) => {
       await reloadProviders();
       broadcast({ kind: "providers", ...(await providerCatalog()) });
       return json(res, 200, await providerCatalog());
+    }
+
+    // ── custom OpenAI-compatible hosts: URL plus one or more keys ──
+    if (method === "GET" && path === "/api/custom-endpoints") {
+      return json(res, 200, customCatalog());
+    }
+    if (method === "POST" && path === "/api/custom-endpoints") {
+      const body = await readBody(req);
+      const name = clamp(body.name, MAX_NAME_CHARS);
+      const url = typeof body.url === "string" ? normalizeCompatUrl(body.url) : undefined;
+      const parsed = parseCustomKey(body);
+      if (!name) return json(res, 400, { error: "a name is required" });
+      if (!url) return json(res, 400, { error: "the endpoint must be an http or https URL" });
+      if (url.length > MAX_URL_CHARS) return json(res, 413, { error: "that URL is too long" });
+      if (parsed.error) return json(res, parsed.error.includes("too long") ? 413 : 400, { error: parsed.error });
+      if ((cfg.custom ?? []).length >= MAX_CUSTOM_ENDPOINTS) {
+        return json(res, 507, { error: `at most ${MAX_CUSTOM_ENDPOINTS} custom endpoints` });
+      }
+      const cred: CustomKey = { id: randomBytes(8).toString("hex"), key: parsed.key!, ...(parsed.label ? { label: parsed.label } : {}) };
+      const entry: CustomEndpoint = {
+        id: randomBytes(8).toString("hex"),
+        name,
+        url,
+        keys: [cred],
+        activeKeyId: cred.id,
+      };
+      await persistCustom([...(cfg.custom ?? []), entry]);
+      return json(res, 201, customCatalog());
+    }
+    m = path.match(/^\/api\/custom-endpoints\/([\w-]+)$/);
+    if (m && method === "DELETE") {
+      const next = (cfg.custom ?? []).filter((endpoint) => endpoint.id !== m![1]);
+      if (next.length === (cfg.custom ?? []).length) return json(res, 404, { error: "no such endpoint" });
+      await persistCustom(next);
+      return json(res, 200, customCatalog());
+    }
+    m = path.match(/^\/api\/custom-endpoints\/([\w-]+)\/keys$/);
+    if (m && method === "POST") {
+      const endpoint = (cfg.custom ?? []).find((entry) => entry.id === m![1]);
+      if (!endpoint) return json(res, 404, { error: "no such endpoint" });
+      const body = await readBody(req);
+      const parsed = parseCustomKey(body);
+      if (parsed.error) return json(res, parsed.error.includes("too long") ? 413 : 400, { error: parsed.error });
+      if (endpoint.keys.length >= MAX_CUSTOM_KEYS) {
+        return json(res, 507, { error: `at most ${MAX_CUSTOM_KEYS} keys on one host` });
+      }
+      const cred: CustomKey = { id: randomBytes(8).toString("hex"), key: parsed.key!, ...(parsed.label ? { label: parsed.label } : {}) };
+      const next = (cfg.custom ?? []).map((entry) =>
+        entry.id === endpoint.id ? { ...entry, keys: [...entry.keys, cred] } : entry,
+      );
+      await persistCustom(next);
+      return json(res, 201, customCatalog());
+    }
+    m = path.match(/^\/api\/custom-endpoints\/([\w-]+)\/keys\/([\w-]+)$/);
+    if (m && method === "DELETE") {
+      const endpoint = (cfg.custom ?? []).find((entry) => entry.id === m![1]);
+      if (!endpoint) return json(res, 404, { error: "no such endpoint" });
+      const remaining = endpoint.keys.filter((cred) => cred.id !== m![2]);
+      if (remaining.length === endpoint.keys.length) return json(res, 404, { error: "no such key" });
+      // the last key is the host: drop the endpoint rather than leave a
+      // connected row that cannot talk to anything
+      if (!remaining.length) {
+        await persistCustom((cfg.custom ?? []).filter((entry) => entry.id !== endpoint.id));
+        return json(res, 200, customCatalog());
+      }
+      const activeKeyId =
+        endpoint.activeKeyId === m[2] ? remaining[0].id : endpoint.activeKeyId;
+      const next = (cfg.custom ?? []).map((entry) =>
+        entry.id === endpoint.id ? { ...entry, keys: remaining, activeKeyId } : entry,
+      );
+      await persistCustom(next);
+      return json(res, 200, customCatalog());
+    }
+    m = path.match(/^\/api\/custom-endpoints\/([\w-]+)\/keys\/([\w-]+)\/use$/);
+    if (m && method === "POST") {
+      const endpoint = (cfg.custom ?? []).find((entry) => entry.id === m![1]);
+      if (!endpoint) return json(res, 404, { error: "no such endpoint" });
+      if (!endpoint.keys.some((cred) => cred.id === m![2])) return json(res, 404, { error: "no such key" });
+      const next = (cfg.custom ?? []).map((entry) =>
+        entry.id === endpoint.id ? { ...entry, activeKeyId: m![2] } : entry,
+      );
+      await persistCustom(next);
+      return json(res, 200, customCatalog());
     }
 
     // ── browser sign-in (OAuth PKCE) ──
@@ -6189,6 +6323,7 @@ function redactSecrets(message: string): string {
     cfg.composio?.apiKey,
     cfg.box?.token,
     ...Object.values(cfg.providers ?? {}).map((p) => p?.key),
+    ...(cfg.custom ?? []).flatMap((endpoint) => endpoint.keys.map((cred) => cred.key)),
     ...Object.values(cfg.secrets ?? {}),
   ];
   for (const secret of stored) {

--- a/server/limits.ts
+++ b/server/limits.ts
@@ -26,6 +26,12 @@ export const MAX_BODY_BYTES = 2_000_000;
 /** Simultaneous event-stream listeners. One app needs one. */
 export const MAX_SSE_CLIENTS = 32;
 
+/** User-added OpenAI-compatible hosts, and keys on one host. */
+export const MAX_CUSTOM_ENDPOINTS = 16;
+export const MAX_CUSTOM_KEYS = 8;
+export const MAX_KEY_CHARS = 400;
+export const MAX_URL_CHARS = 400;
+
 /** Trims a value to a cap, returning undefined when there is nothing
  * left. Callers decide whether absent means "skip" or "reject". */
 export function clamp(value: unknown, max: number): string | undefined {

--- a/server/providers.ts
+++ b/server/providers.ts
@@ -235,8 +235,42 @@ export const PROVIDER_SPECS: readonly ProviderSpec[] = [
   OLLAMA,
 ];
 
+/** A user-added OpenAI-compatible host. The URL and keys live in
+ * config.json, not here: this is only the driver shape, so one generic
+ * instance can point at any /v1 that speaks chat completions. Tools stay
+ * off because support depends on whatever is loaded behind that URL. */
+export const CUSTOM_SPEC: ProviderSpec = {
+  kind: "custom",
+  name: "Custom",
+  url: "",
+  auth: "key",
+  keyHint: "API key from your OpenAI-compatible endpoint",
+  docsUrl: "https://platform.openai.com/docs/api-reference/models",
+  models: { default: "", options: [] },
+  limit: 32,
+};
+
 export function specFor(kind: string): ProviderSpec | undefined {
+  if (kind === CUSTOM_SPEC.kind) return CUSTOM_SPEC;
   return PROVIDER_SPECS.find((s) => s.kind === kind);
+}
+
+/** The OpenAI-compatible root a person meant. Trailing slashes and a
+ * pasted /chat/completions path are the two ways a working host becomes
+ * a 404 on /models, so both get folded here rather than stored as typed. */
+export function normalizeCompatUrl(url: string): string | undefined {
+  const trimmed = url.trim();
+  if (!/^https?:\/\//i.test(trimmed) || trimmed.length > 400) return undefined;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.username || parsed.password) return undefined;
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    let path = parsed.pathname.replace(/\/+$/, "");
+    path = path.replace(/\/(chat\/)?completions$/i, "");
+    return `${parsed.protocol}//${parsed.host}${path}`;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Engines that come from a CLI on this machine. They are not configured

--- a/src/components/CustomEndpoints.tsx
+++ b/src/components/CustomEndpoints.tsx
@@ -1,0 +1,306 @@
+// User-added OpenAI-compatible hosts.
+//
+// The catalog covers the labs Bloks already knows. This is the open
+// slot: any /v1 that speaks chat completions, with as many keys as that
+// host issued. Keys never come back out; the list is names, URLs, and
+// whether a key is the one the live instance is using.
+import { useCallback, useEffect, useState } from "react";
+import Check from "lucide-react/dist/esm/icons/check.js";
+import Plus from "lucide-react/dist/esm/icons/plus.js";
+import Trash2 from "lucide-react/dist/esm/icons/trash-2.js";
+import { api, useStore } from "@/state/store";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/cn";
+
+export interface CustomKeyRow {
+  id: string;
+  label: string;
+  active: boolean;
+}
+
+export interface CustomEndpointRow {
+  id: string;
+  name: string;
+  url: string;
+  instanceId: string;
+  activeKeyId: string | null;
+  keys: CustomKeyRow[];
+}
+
+function refreshInstances(dispatch: ReturnType<typeof useStore>["dispatch"]) {
+  api("/api/instances")
+    .then(({ instances }) => dispatch({ type: "instances", instances }))
+    .catch(() => {});
+}
+
+export function CustomEndpoints() {
+  const { dispatch } = useStore();
+  const [endpoints, setEndpoints] = useState<CustomEndpointRow[] | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [key, setKey] = useState("");
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [keyFor, setKeyFor] = useState<string | null>(null);
+  const [extraKey, setExtraKey] = useState("");
+  const [extraLabel, setExtraLabel] = useState("");
+
+  const reload = useCallback(() => {
+    api("/api/custom-endpoints")
+      .then(({ endpoints: rows }) => setEndpoints(rows ?? []))
+      .catch(() => setEndpoints([]));
+  }, []);
+
+  useEffect(reload, [reload]);
+
+  const apply = (rows: CustomEndpointRow[]) => {
+    setEndpoints(rows);
+    refreshInstances(dispatch);
+  };
+
+  const add = () => {
+    if (busy || !name.trim() || !url.trim() || !key.trim()) return;
+    setBusy(true);
+    setError(null);
+    api("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({
+        name: name.trim(),
+        url: url.trim(),
+        key: key.trim(),
+        ...(label.trim() ? { label: label.trim() } : {}),
+      }),
+    })
+      .then(({ endpoints: rows }) => {
+        apply(rows);
+        setAdding(false);
+        setName("");
+        setUrl("");
+        setKey("");
+        setLabel("");
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setBusy(false));
+  };
+
+  const addKey = (id: string) => {
+    if (busy || !extraKey.trim()) return;
+    setBusy(true);
+    setError(null);
+    api(`/api/custom-endpoints/${id}/keys`, {
+      method: "POST",
+      body: JSON.stringify({
+        key: extraKey.trim(),
+        ...(extraLabel.trim() ? { label: extraLabel.trim() } : {}),
+      }),
+    })
+      .then(({ endpoints: rows }) => {
+        apply(rows);
+        setKeyFor(null);
+        setExtraKey("");
+        setExtraLabel("");
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setBusy(false));
+  };
+
+  return (
+    <div className="mt-4 overflow-hidden rounded-2xl border bg-card">
+      <div className="px-4 pb-3 pt-4">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <div className="text-[13.5px] font-semibold text-foreground">Your endpoints</div>
+            <div className="mt-0.5 text-[12.5px] leading-relaxed text-muted-foreground">
+              Any OpenAI-compatible host. Several keys can share one URL; the marked one is what
+              agents use.
+            </div>
+          </div>
+          {!adding && (
+            <Button variant="secondary" size="sm" onClick={() => setAdding(true)} className="shrink-0">
+              <Plus size={13} />
+              Add
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {(endpoints ?? []).map((endpoint) => (
+        <div key={endpoint.id} className="border-t px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[13.5px] font-medium text-foreground">{endpoint.name}</div>
+              <div className="truncate text-[12px] text-muted-foreground">{endpoint.url}</div>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                void api(`/api/custom-endpoints/${endpoint.id}`, { method: "DELETE" })
+                  .then(({ endpoints: rows }) => apply(rows))
+                  .catch((e: Error) => setError(e.message))
+              }
+              className="shrink-0 text-muted-foreground hover:text-destructive"
+            >
+              Remove
+            </Button>
+          </div>
+
+          <div className="mt-2 flex flex-col gap-1">
+            {endpoint.keys.map((cred, index) => (
+              <div key={cred.id} className="flex items-center gap-2 rounded-lg bg-muted/50 px-2.5 py-1.5">
+                <span
+                  className={cn("size-1.5 rounded-full", cred.active ? "bg-success" : "bg-muted-foreground/30")}
+                />
+                <span className="min-w-0 flex-1 truncate text-[12.5px] text-foreground">
+                  {cred.label || (endpoint.keys.length > 1 ? `Key ${index + 1}` : "API key")}
+                  {cred.active && (
+                    <span className="ml-1.5 text-[11px] font-normal text-success">In use</span>
+                  )}
+                </span>
+                {!cred.active && (
+                  <button
+                    onClick={() =>
+                      void api(`/api/custom-endpoints/${endpoint.id}/keys/${cred.id}/use`, {
+                        method: "POST",
+                      })
+                        .then(({ endpoints: rows }) => apply(rows))
+                        .catch((e: Error) => setError(e.message))
+                    }
+                    className="shrink-0 text-[11.5px] text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Use
+                  </button>
+                )}
+                <button
+                  onClick={() =>
+                    void api(`/api/custom-endpoints/${endpoint.id}/keys/${cred.id}`, {
+                      method: "DELETE",
+                    })
+                      .then(({ endpoints: rows }) => apply(rows))
+                      .catch((e: Error) => setError(e.message))
+                  }
+                  title="Remove this key"
+                  className="shrink-0 rounded-lg p-1 text-muted-foreground/60 transition-colors hover:text-destructive"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {keyFor === endpoint.id ? (
+            <div className="mt-2 flex flex-col gap-2">
+              <div className="flex gap-2">
+                <Input
+                  autoFocus
+                  type="password"
+                  value={extraKey}
+                  onChange={(e) => setExtraKey(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") addKey(endpoint.id);
+                    if (e.key === "Escape") setKeyFor(null);
+                  }}
+                  placeholder="Another key for this host"
+                  autoComplete="off"
+                  className="h-8 text-[13px]"
+                />
+                <Button
+                  variant="secondary"
+                  onClick={() => addKey(endpoint.id)}
+                  disabled={busy || !extraKey.trim()}
+                  className="w-[72px]"
+                >
+                  <Check size={13} />
+                  Save
+                </Button>
+              </div>
+              <Input
+                value={extraLabel}
+                onChange={(e) => setExtraLabel(e.target.value)}
+                placeholder="Label (optional), e.g. backup"
+                className="h-8 text-[13px]"
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => {
+                setKeyFor(endpoint.id);
+                setError(null);
+              }}
+              className="mt-2 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Add another key
+            </button>
+          )}
+        </div>
+      ))}
+
+      {endpoints !== null && endpoints.length === 0 && !adding && (
+        <div className="border-t px-4 py-3 text-[12.5px] text-muted-foreground">
+          Nothing added yet. LiteLLM, vLLM, a proxy, or any host that answers /v1/models.
+        </div>
+      )}
+
+      {adding && (
+        <div className="border-t px-4 py-3">
+          <div className="flex flex-col gap-2">
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Name, e.g. Together"
+              className="h-8 text-[13px]"
+            />
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="Base URL, usually ending in /v1"
+              className="h-8 text-[13px]"
+            />
+            <Input
+              type="password"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && add()}
+              placeholder="API key"
+              autoComplete="off"
+              className="h-8 text-[13px]"
+            />
+            <Input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Key label (optional)"
+              className="h-8 text-[13px]"
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setAdding(false);
+                  setError(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={add}
+                disabled={busy || !name.trim() || !url.trim() || !key.trim()}
+              >
+                <Check size={13} />
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && <div className="border-t px-4 py-2 text-[12px] text-destructive">{error}</div>}
+    </div>
+  );
+}

--- a/src/components/EnginesPanel.tsx
+++ b/src/components/EnginesPanel.tsx
@@ -10,6 +10,7 @@ import ExternalLink from "lucide-react/dist/esm/icons/external-link.js";
 import Loader2 from "lucide-react/dist/esm/icons/loader-2.js";
 import Plus from "lucide-react/dist/esm/icons/plus.js";
 import { api, useStore, type ProviderRow } from "@/state/store";
+import { CustomEndpoints } from "./CustomEndpoints";
 import { ProviderMark } from "./ProviderIcons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -203,26 +204,29 @@ export function EnginesPanel() {
   const chat = providers.filter((p) => !p.agentic);
 
   return (
-    <div className="mt-4 overflow-hidden rounded-2xl border bg-card">
-      <div className="px-4 pb-3 pt-4">
-        <div className="flex items-baseline justify-between gap-2">
-          <div className="text-[13.5px] font-semibold text-foreground">Engines</div>
-          <div className="text-[11.5px] text-muted-foreground">{connected} connected</div>
+    <>
+      <div className="mt-4 overflow-hidden rounded-2xl border bg-card">
+        <div className="px-4 pb-3 pt-4">
+          <div className="flex items-baseline justify-between gap-2">
+            <div className="text-[13.5px] font-semibold text-foreground">Engines</div>
+            <div className="text-[11.5px] text-muted-foreground">{connected} connected</div>
+          </div>
+          <div className="mt-0.5 text-[12.5px] leading-relaxed text-muted-foreground">
+            What your agents run on. Keys stay on this machine.
+          </div>
         </div>
-        <div className="mt-0.5 text-[12.5px] leading-relaxed text-muted-foreground">
-          What your agents run on. Keys stay on this machine.
-        </div>
+        <Group
+          title="Agents"
+          note="Run commands and read files. Install the CLI, then sign in."
+          rows={agents}
+        />
+        <Group
+          title="Chat models"
+          note="Write and reason, but cannot act on your machine."
+          rows={chat}
+        />
       </div>
-      <Group
-        title="Agents"
-        note="Run commands and read files. Install the CLI, then sign in."
-        rows={agents}
-      />
-      <Group
-        title="Chat models"
-        note="Write and reason, but cannot act on your machine."
-        rows={chat}
-      />
-    </div>
+      <CustomEndpoints />
+    </>
   );
 }

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -140,6 +140,7 @@ const LETTERED: Record<string, { letter: string; tone: string }> = {
   mistral: { letter: "M", tone: "#fa520f" },
   groq: { letter: "G", tone: "#f55036" },
   ollama: { letter: "O", tone: "#6b7280" },
+  custom: { letter: "C", tone: "#6b7280" },
 };
 
 export function ProviderMark({ driverKind, size, className }: IconProps & { driverKind: string }) {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -217,6 +217,193 @@ describe("the engine catalog", () => {
   });
 });
 
+describe("custom OpenAI-compatible endpoints", () => {
+  test("a host plus a key becomes an instance, and the key never comes back", async (t) => {
+    const { createServer } = await import("node:http");
+    const seen: string[] = [];
+    const fake = createServer((req, res) => {
+      if (req.url?.endsWith("/models")) {
+        seen.push(String(req.headers.authorization ?? ""));
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ data: [{ id: "acct-large" }, { id: "acct-small" }] }));
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => fake.listen(0, "127.0.0.1", () => r()));
+    t.after(() => fake.close());
+    const port = (fake.address() as any).port;
+
+    const secret = "sk-custom-super-secret-value-123456";
+    const created = await h.fetch("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Acct",
+        url: `http://127.0.0.1:${port}/v1/`,
+        key: secret,
+        label: "work",
+      }),
+    });
+    assert.equal(created.status, 201);
+    const listed = await created.json();
+    const endpoint = listed.endpoints.find((e: any) => e.name === "Acct");
+    assert.ok(endpoint);
+    t.after(() => h.fetch(`/api/custom-endpoints/${endpoint.id}`, { method: "DELETE" }));
+    assert.equal(endpoint.url, `http://127.0.0.1:${port}/v1`);
+    assert.equal(endpoint.keys.length, 1);
+    assert.equal(endpoint.keys[0].label, "work");
+    assert.equal(endpoint.keys[0].active, true);
+    const echoed = JSON.stringify(listed);
+    assert.ok(!echoed.includes(secret), "a custom key leaked into the create response");
+
+    const saved = readFileSync(join(h.home, ".bloks", "config.json"), "utf8");
+    assert.ok(saved.includes(secret), "the key should be on disk");
+    const { mode } = statSync(join(h.home, ".bloks", "config.json"));
+    assert.equal(mode & 0o077, 0, "config.json is group or world readable");
+
+    const instances = await h.json("/api/instances");
+    const custom = instances.instances.find((i: any) => i.instanceId === endpoint.instanceId);
+    assert.ok(custom, "the host should appear as an instance");
+    assert.equal(custom.driverKind, "custom");
+    assert.equal(custom.displayName, "Acct");
+    assert.ok(
+      custom.models.options.some((o: any) => o.id === "acct-large"),
+      "GET /models should populate the picker",
+    );
+    assert.ok(!JSON.stringify(instances).includes(secret), "a custom key leaked into /api/instances");
+  });
+
+  test("several keys share one host, and Use rotates which one is sent", async (t) => {
+    const { createServer } = await import("node:http");
+    const auths: string[] = [];
+    const fake = createServer((req, res) => {
+      if (req.url?.endsWith("/models")) {
+        auths.push(String(req.headers.authorization ?? ""));
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ data: [{ id: "shared-model" }] }));
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => fake.listen(0, "127.0.0.1", () => r()));
+    t.after(() => fake.close());
+    const port = (fake.address() as any).port;
+    const first = "sk-custom-first-key-aaaaaaaa";
+    const second = "sk-custom-second-key-bbbbbbbb";
+
+    const { endpoints: created } = await h.json("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Shared",
+        url: `http://127.0.0.1:${port}/v1`,
+        key: first,
+        label: "primary",
+      }),
+    });
+    const id = created[0].id;
+    const added = await h.json(`/api/custom-endpoints/${id}/keys`, {
+      method: "POST",
+      body: JSON.stringify({ key: second, label: "backup" }),
+    });
+    assert.equal(added.endpoints[0].keys.length, 2);
+    assert.equal(added.endpoints[0].keys.filter((k: any) => k.active).length, 1);
+    assert.equal(
+      added.endpoints[0].keys.find((k: any) => k.label === "primary").active,
+      true,
+      "the first key stays in use until someone picks another",
+    );
+
+    await h.json("/api/instances");
+    await waitFor(async () => (auths.some((a) => a.includes(first)) ? true : null));
+    assert.ok(
+      auths.some((a) => a.includes(first)),
+      "the active key should be the one sent to /models",
+    );
+    assert.ok(
+      !auths.some((a) => a.includes(second)),
+      "the unused key should stay off the wire",
+    );
+
+    const backup = added.endpoints[0].keys.find((k: any) => k.label === "backup");
+    auths.length = 0;
+    const rotated = await h.json(`/api/custom-endpoints/${id}/keys/${backup.id}/use`, {
+      method: "POST",
+    });
+    assert.equal(rotated.endpoints[0].keys.find((k: any) => k.label === "backup").active, true);
+
+    await h.json("/api/instances");
+    await waitFor(async () => (auths.some((a) => a.includes(second)) ? true : null));
+    assert.ok(auths.some((a) => a.includes(second)), "Use should send the newly active key");
+    assert.ok(!auths.some((a) => a.includes(first)), "the previous key should no longer be sent");
+
+    t.after(() => h.fetch(`/api/custom-endpoints/${id}`, { method: "DELETE" }));
+  });
+
+  test("a pasted completions URL is stored as the /v1 root", async () => {
+    const made = await h.json("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Trimmed",
+        url: "https://api.example.test/v1/chat/completions",
+        key: "sk-custom-trim-key-cccccccc",
+      }),
+    });
+    const trimmed = made.endpoints.find((e: any) => e.name === "Trimmed");
+    assert.equal(trimmed.url, "https://api.example.test/v1");
+    await h.fetch(`/api/custom-endpoints/${trimmed.id}`, { method: "DELETE" });
+  });
+
+  test("a bad URL or a missing key is refused", async () => {
+    const noUrl = await h.fetch("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({ name: "Nope", url: "not-a-url", key: "sk-custom-bad-dddddddd" }),
+    });
+    assert.equal(noUrl.status, 400);
+    const noKey = await h.fetch("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({ name: "Nope", url: "https://api.example.test/v1" }),
+    });
+    assert.equal(noKey.status, 400);
+    const userinfo = await h.fetch("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Nope",
+        url: "https://user:pass@api.example.test/v1",
+        key: "sk-custom-bad-eeeeeeee",
+      }),
+    });
+    assert.equal(userinfo.status, 400, "credentials in the URL are not a key field");
+  });
+
+  test("removing the last key forgets the host", async () => {
+    const made = await h.json("/api/custom-endpoints", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Temp",
+        url: "https://api.example.test/v1",
+        key: "sk-custom-temp-key-ffffffff",
+      }),
+    });
+    const endpoint = made.endpoints.find((e: any) => e.name === "Temp");
+    const gone = await h.json(`/api/custom-endpoints/${endpoint.id}/keys/${endpoint.keys[0].id}`, {
+      method: "DELETE",
+    });
+    assert.ok(!gone.endpoints.some((e: any) => e.id === endpoint.id));
+    const disk = JSON.parse(readFileSync(join(h.home, ".bloks", "config.json"), "utf8"));
+    assert.ok(!(disk.custom ?? []).some((e: any) => e.id === endpoint.id));
+  });
+
+  test("custom is not a row in the static catalog", async () => {
+    const { providers } = await h.json("/api/providers");
+    assert.ok(!providers.some((p: any) => p.kind === "custom"));
+    const refused = await h.fetch("/api/providers/custom/connect", {
+      method: "POST",
+      body: JSON.stringify({ key: "sk-nope", url: "https://api.example.test/v1" }),
+    });
+    assert.equal(refused.status, 400);
+  });
+});
+
 describe("skills", () => {
   test("a builtin library ships with the app", async () => {
     const { skills } = await h.json("/api/skills");

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -332,7 +332,7 @@ test("every config section the server writes is one saveConfig will keep", async
   const written = [...source("../server/index.ts").matchAll(/saveConfig\(\{\s*(\w+):/g)].map((m) => m[1]);
   assert.ok(written.length > 0, "no saveConfig calls found, so this proves nothing");
   const missing = [...new Set(written)].filter(
-    (key) => !allowed.has(key) && !["mcpServers", "setupDoneAt"].includes(key),
+    (key) => !allowed.has(key) && !["mcpServers", "custom", "setupDoneAt"].includes(key),
   );
   assert.deepEqual(missing, [], `these would be written and then dropped: ${missing.join(", ")}`);
 });

--- a/test/custom-endpoints.test.ts
+++ b/test/custom-endpoints.test.ts
@@ -1,0 +1,72 @@
+// URL folding for a pasted OpenAI-compatible host, and how several keys
+// on that host become one live instance.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { activeCustomKey, customInstanceId, instanceConfigs, type AppConfig } from "../server/config.ts";
+import { CUSTOM_SPEC, normalizeCompatUrl } from "../server/providers.ts";
+
+test("a trailing slash and a completions path fold to the same root", () => {
+  assert.equal(normalizeCompatUrl("https://api.example.test/v1/"), "https://api.example.test/v1");
+  assert.equal(
+    normalizeCompatUrl("https://api.example.test/v1/chat/completions"),
+    "https://api.example.test/v1",
+  );
+  assert.equal(
+    normalizeCompatUrl("https://api.example.test/v1/completions"),
+    "https://api.example.test/v1",
+  );
+});
+
+test("only http(s) URLs without embedded credentials are kept", () => {
+  assert.equal(normalizeCompatUrl("not-a-url"), undefined);
+  assert.equal(normalizeCompatUrl("ftp://api.example.test/v1"), undefined);
+  assert.equal(normalizeCompatUrl("https://user:secret@api.example.test/v1"), undefined);
+  assert.equal(normalizeCompatUrl(""), undefined);
+});
+
+test("the active key is the named one, or the first that still has a value", () => {
+  const keys = [
+    { id: "a", key: "one" },
+    { id: "b", label: "backup", key: "two" },
+  ];
+  assert.equal(activeCustomKey({ id: "e", name: "E", url: "https://x", keys, activeKeyId: "b" })?.id, "b");
+  assert.equal(activeCustomKey({ id: "e", name: "E", url: "https://x", keys })?.id, "a");
+  assert.equal(
+    activeCustomKey({
+      id: "e",
+      name: "E",
+      url: "https://x",
+      keys: [{ id: "a", key: "" }, { id: "b", key: "two" }],
+    })?.id,
+    "b",
+  );
+});
+
+test("a custom host becomes one instance that carries the active key", () => {
+  const cfg: AppConfig = {
+    custom: [
+      {
+        id: "host1",
+        name: "Together",
+        url: "https://api.together.xyz/v1",
+        keys: [
+          { id: "k1", label: "work", key: "sk-work" },
+          { id: "k2", label: "home", key: "sk-home" },
+        ],
+        activeKeyId: "k2",
+      },
+    ],
+  };
+  const map = instanceConfigs(cfg);
+  const instance = map[customInstanceId("host1")];
+  assert.ok(instance);
+  assert.equal(instance.driver, CUSTOM_SPEC.kind);
+  assert.equal(instance.displayName, "Together");
+  assert.deepEqual(instance.config, { url: "https://api.together.xyz/v1" });
+  assert.equal(instance.environment?.[`${CUSTOM_SPEC.kind.toUpperCase()}_API_KEY`], "sk-home");
+  assert.ok(
+    !Object.values(map).some((entry) => entry.environment?.[`${CUSTOM_SPEC.kind.toUpperCase()}_API_KEY`] === "sk-work"),
+    "the unused key must not be injected into any instance",
+  );
+});


### PR DESCRIPTION
## What this changes

Settings can add a third-party OpenAI-compatible inference host: a name, a base URL, and one or more API keys. Several keys can share the same URL. The marked key is what the live engine sends. `GET /models` fills the model picker the same way it does for catalog engines.

## Why

The catalog covers the labs Bloks already knows. People also run LiteLLM, vLLM, a company proxy, or any other `/v1` host, and they often have more than one key for that host. That belongs in Settings, with keys in `config.json` at mode `0600`, not as a new client-side transport.

## User-facing behavior

- Settings → Engines → **Your endpoints**: add a host (name, base URL, first key).
- **Add another key** on that host. Optional labels tell two keys apart.
- **Use** marks which key the instance sends. Agents already on that host keep the same instance id, so rotating a key does not rebind them.
- Removing the last key removes the host.
- The picker lists the host once the instance is up, with models from `GET {base}/models`.
- Keys are write-only. The API returns names, URLs, and labels, never the secret.

A pasted `/v1/` or `/v1/chat/completions` URL is stored as the `/v1` root. Credentials in the URL (`user:pass@host`) are refused.

## How it fits the architecture

- The client still holds no transports. Settings POSTs to the harness; the generic OpenAI-compat driver talks to the host.
- `CUSTOM_SPEC` in `server/providers.ts` is the data entry. `openAiCompatDriver` is reused.
- Secrets stay in `~/.bloks/config.json` under `custom[]`, same `0600` file as the other keys.
- One instance per host (`custom_<id>`), not one instance per key, so rotate is a settings change rather than a new rail icon.

## How you verified it

Ran `pnpm typecheck && pnpm test && pnpm build` on Node 22.22.2.

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes: 892 tests, 0 failed. New coverage: six request-path tests in `test/api.test.ts` (create, key never echoed, `0600`, `/models` discovery, two keys plus Use rotates the Authorization header, URL folding, refusals, last-key delete) and four unit tests in `test/custom-endpoints.test.ts`.
- [x] `pnpm build` passes (tsc + vite)
- [x] Ran the app (`pnpm dev:server` + `pnpm dev`) and used Settings → Engines → Your endpoints: added a host, added a second labeled key, clicked Use, confirmed the raw keys never appeared on screen.

## Anything a reviewer should push back on

- Tools stay off for custom hosts. Support depends on whatever is loaded behind the URL, same reason Ollama does not promise them. A later PR could add a per-host toggle.
- One instance per host, not per key. Different agents cannot use two keys on the same host at once unless you add the host twice (we do not merge same URLs).
- No env-var shortcut (`CUSTOM_API_KEY` + `CUSTOM_API_URL`). Easy to add if wanted.

- [x] I read CONTRIBUTING.md
- [x] This does not weaken the approval gate
- [x] Any new field that reaches disk or a system prompt has a length cap