### PR TITLE
Give the Grok CLI its own icon

### DIFF
--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -17,6 +17,30 @@ export function GrokMark({ size = 16, className }: IconProps) {
   );
 }
 
+/** The Grok CLI. The app tile, while the API engine keeps the bare
+ * swoosh: same brand, two different things to click. */
+export function GrokCliMark({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 509.641"
+      shapeRendering="geometricPrecision"
+      textRendering="geometricPrecision"
+      imageRendering="optimizeQuality"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      className={cn(className)}
+    >
+      <path d="M115.612 0h280.776C459.975 0 512 52.026 512 115.612v278.416c0 63.587-52.025 115.613-115.612 115.613H115.612C52.026 509.641 0 457.615 0 394.028V115.612C0 52.026 52.026 0 115.612 0z" fill="#000" />
+      <path
+        fill="#fff"
+        d="M213.235 306.019l178.976-180.002v.169l51.695-51.763c-.924 1.32-1.86 2.605-2.785 3.89-39.281 54.164-58.46 80.649-43.07 146.922l-.09-.101c10.61 45.11-.744 95.137-37.398 131.836-46.216 46.306-120.167 56.611-181.063 14.928l42.462-19.675c38.863 15.278 81.392 8.57 111.947-22.03 30.566-30.6 37.432-75.159 22.065-112.252-2.92-7.025-11.67-8.795-17.792-4.263l-124.947 92.341zm-25.786 22.437l-.033.034L68.094 435.217c7.565-10.429 16.957-20.294 26.327-30.149 26.428-27.803 52.653-55.359 36.654-94.302-21.422-52.112-8.952-113.177 30.724-152.898 41.243-41.254 101.98-51.661 152.706-30.758 11.23 4.172 21.016 10.114 28.638 15.639l-42.359 19.584c-39.44-16.563-84.629-5.299-112.207 22.313-37.298 37.308-44.84 102.003-1.128 143.81z"
+      />
+    </svg>
+  );
+}
+
 export function ClaudeMark({ size = 16, className }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 256 257" preserveAspectRatio="xMidYMid" className={cn("fill-[#d97757]", className)}>
@@ -147,6 +171,8 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
   switch (driverKind) {
     case "grok":
       return <GrokMark size={size} className={className} />;
+    case "grokCli":
+      return <GrokCliMark size={size} className={className} />;
     case "claudeAgent":
       return <ClaudeMark size={size} className={className} />;
     case "codex":


### PR DESCRIPTION
The Grok API engine and the Grok CLI were sharing one mark. They are two different things to click, so the CLI now uses the app tile and the API engine keeps the swoosh.

<img width="458" height="242" alt="image" src="https://github.com/user-attachments/assets/299dd73e-8bb0-4cee-9474-8fa0fd1dccce" />