### PR TITLE
Add Pi as an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ provider offers and do the volume; the lead keeps its costlier model for
 review. That is the whole economics of it, and it is the same reason a
 company has juniors.
 
-**Any engine.** Claude Code, Codex and Gemini CLI run as real agents that
+**Any engine.** Claude Code, Codex, Gemini CLI and Pi run as real agents that
 use tools and touch files. Gemini, Grok, Kimi, Llama, DeepSeek, Mistral,
 Groq, OpenRouter and Ollama connect as chat engines. A custom
 OpenAI-compatible host takes a base URL and one or more keys. OpenRouter has a
@@ -128,6 +128,7 @@ You need one of these before an agent can reply. Any of them works.
 | Claude Code | `npm i -g @anthropic-ai/claude-code`, then `claude` | yes |
 | Codex | `npm i -g @openai/codex`, then `codex login` | yes |
 | Gemini CLI | `npm i -g @google/gemini-cli`, then a Google sign-in or a Gemini key | yes |
+| Pi | `npm i -g --ignore-scripts @earendil-works/pi-coding-agent && npm i -g pi-acp`, then `pi` (or `pi-acp --terminal-login`) | yes |
 | OpenRouter | Sign in from Settings, in your browser | no |
 | Gemini, Grok, Kimi, Llama, DeepSeek, Mistral, Groq | Paste a key in Settings | no |
 | Custom (OpenAI-compatible) | Paste a base URL and key(s) in Settings | no |

--- a/server/agent-cli.ts
+++ b/server/agent-cli.ts
@@ -236,7 +236,7 @@ export function capabilities(): string[] {
  * them rather than excluding the two obvious ones means a driver added
  * later gets nothing until somebody has decided it should.
  */
-export const CLI_DRIVERS = new Set(["claudeAgent", "codex", "antigravity", "opencode", "grokCli"]);
+export const CLI_DRIVERS = new Set(["claudeAgent", "codex", "antigravity", "opencode", "grokCli", "pi"]);
 
 export function runsAProcess(driverKind: string): boolean {
   return CLI_DRIVERS.has(driverKind);

--- a/server/config.ts
+++ b/server/config.ts
@@ -280,19 +280,31 @@ export function disconnectProvider(kind: string): void {
 // provider that has been connected, whose instance id defaults to the
 // driver kind. Config-file keys are injected as per-instance environment
 // so drivers see them without needing real process env vars.
+const BUILT_IN_CLI_INSTANCES: InstanceConfigMap = {
+  claude: { driver: "claudeAgent" },
+  codex: { driver: "codex" },
+  gemini_cli: { driver: "geminiCli" },
+  opencode: { driver: "opencode" },
+  grok_cli: { driver: "grokCli" },
+  antigravity: { driver: "antigravity" },
+  pi: { driver: "pi" },
+  computer: { driver: "boxAgent" },
+};
+
 export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
   const map: InstanceConfigMap =
     cfg.instances && Object.keys(cfg.instances).length
       ? { ...cfg.instances }
-      : {
-          claude: { driver: "claudeAgent" },
-          codex: { driver: "codex" },
-          gemini_cli: { driver: "geminiCli" },
-          opencode: { driver: "opencode" },
-          grok_cli: { driver: "grokCli" },
-          antigravity: { driver: "antigravity" },
-          computer: { driver: "boxAgent" },
-        };
+      : Object.fromEntries(
+          Object.entries(BUILT_IN_CLI_INSTANCES).map(([id, entry]) => [id, { ...entry }]),
+        );
+  // A build that adds a CLI has to appear for people who already have
+  // an instances map, or the new engine is a catalog row that never
+  // probes.
+  for (const [id, entry] of Object.entries(BUILT_IN_CLI_INSTANCES)) {
+    if (Object.values(map).some((e) => e.driver === entry.driver)) continue;
+    map[id] = { ...entry };
+  }
   // A connected provider that is not already spelled out in `instances`
   // gets the obvious one: instance id = driver kind.
   for (const kind of connectedProviders(cfg)) {

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -249,6 +249,9 @@ export interface ProviderInstance {
   readonly enabled: boolean;
   readonly models: ModelCatalog;
   readonly adapter: ProviderAdapter;
+  /** Resolves when a deferred catalog probe has finished, if this engine
+   * has one. The picker loads before that, so the harness refetches. */
+  catalogReady?: Promise<void>;
   snapshot(): Promise<ProviderSnapshot>;
   /** A cheap one-shot completion, for naming and summarising. Optional:
    * not every engine has something small enough to be worth using. */

--- a/server/drivers/acp.ts
+++ b/server/drivers/acp.ts
@@ -10,7 +10,10 @@
 // Shapes here were read off the wire from gemini-cli 0.55.1, not guessed:
 //   initialize            -> { protocolVersion, agentCapabilities, agentInfo }
 //   session/new           -> { sessionId, models, modes }
-//   session/load          -> resumes a prior sessionId (loadSession capability)
+//   session/load          -> resumes a prior sessionId (loadSession capability).
+//                            The spec says the agent then replays the whole
+//                            conversation as session/update; Bloks already
+//                            has that transcript, so those frames are dropped.
 //   session/prompt        -> blocks for the turn, returns { stopReason, usage }
 //   session/update        <- streaming notifications (text, tools, thoughts)
 //   session/request_permission <- a real request we must answer
@@ -19,8 +22,8 @@
 // driver. Continuity comes from session/load with the stored id.
 import { spawn, execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type {
@@ -34,6 +37,8 @@ import type {
   SendTurnInput,
 } from "../contracts.ts";
 import { newEventId, newId } from "../contracts.ts";
+import { attachRpc } from "../harness/jsonrpc-stdio.ts";
+import { onPath, widenPath } from "../path.ts";
 import { appendNative } from "./native.ts";
 import { describeEarlyExit, describeSpawnError } from "./spawn-error.ts";
 
@@ -63,6 +68,14 @@ export interface AcpSpec {
   authFiles?: string[];
   /** Used until session/new reports what the agent actually serves. */
   models: ModelCatalog;
+  /** When --version would start a session instead of printing a
+   * version, the install probe is "is this binary on PATH". */
+  probePath?: boolean;
+  /** Engines whose catalog follows their own configuration (pi reads its
+   * connected providers) stay behind the placeholder until the first
+   * turn otherwise. Set to probe a throwaway session for the real
+   * catalog, so the picker lists actual models from the start. */
+  probeModels?: boolean;
 }
 
 export interface AcpConfig {
@@ -73,6 +86,18 @@ export interface AcpConfig {
 }
 
 const PROTOCOL_VERSION = 1;
+
+/** How long a probe session may take to report its catalog. A hung CLI
+ * (pi-acp --version starts a session) will sit forever without this. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+/** We do not lend the agent our filesystem or terminal; it has its own,
+ * and every borrowed capability is another way in. */
+const CLIENT_HELLO = {
+  protocolVersion: PROTOCOL_VERSION,
+  clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+  clientInfo: { name: "bloks", version: "1" },
+};
 
 /** The connectors bridge ships as TypeScript in development and compiled
  * JavaScript in the packaged app; resolve whichever is actually there. */
@@ -86,6 +111,53 @@ function toolTitle(update: any): string {
   const title = typeof update?.title === "string" ? update.title : null;
   if (title) return title.slice(0, 100);
   return typeof update?.kind === "string" ? update.kind : "tool";
+}
+
+function catalogFromSession(session: any): ModelCatalog | null {
+  const available: any[] = session?.models?.availableModels ?? [];
+  if (!available.length) return null;
+  return {
+    default: String(session.models.currentModelId ?? available[0].modelId),
+    options: available.map((m) => ({ id: String(m.modelId), label: String(m.name || m.modelId) })),
+  };
+}
+
+/** The catalog an ACP agent serves, from one throwaway session, or null
+ * when the agent cannot be asked. ACP has no catalog without a session,
+ * so there is no cheaper question. No prompt is sent: nothing is spent,
+ * and the child is killed as soon as the answer lands. */
+async function probeCatalog(spec: AcpSpec, cli: string, env: Record<string, string | undefined>): Promise<ModelCatalog | null> {
+  const child = spawn(cli, spec.args, { cwd: tmpdir(), env, stdio: ["pipe", "pipe", "pipe"] });
+  // a chatty CLI can fill stderr and stall if nobody reads it
+  child.stderr?.resume();
+
+  const rpc = attachRpc({
+    stdin: child.stdin,
+    stdout: child.stdout,
+    onRequest: (msg) => rpc.replyError(msg.id, -32601, "not supported by this client"),
+    onNotify: () => {},
+  });
+
+  const timer = setTimeout(() => rpc.failPending(new Error("timed out")), PROBE_TIMEOUT_MS);
+  timer.unref?.();
+  child.on("error", (e) => rpc.failPending(e instanceof Error ? e : new Error(String(e))));
+  child.on("close", () => rpc.failPending(new Error("exited")));
+
+  try {
+    await rpc.request("initialize", CLIENT_HELLO);
+    const session = await rpc.request("session/new", { cwd: tmpdir(), mcpServers: [] });
+    return catalogFromSession(session);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      /* already gone */
+    }
+    rpc.failPending(new Error("probe ended"));
+  }
 }
 
 export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
@@ -142,6 +214,19 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
         return env;
       };
 
+      // Engines that build their catalog from their own configuration
+      // are probed once with a throwaway session, so the picker starts
+      // with real models. A failed probe leaves the placeholder; the
+      // first turn replaces it with what the agent serves.
+      if (spec.probeModels) {
+        widenPath();
+        void probeCatalog(spec, config.cli, childEnv()).then((catalog) => {
+          if (!catalog) return;
+          models.options = catalog.options;
+          models.default = catalog.default;
+        });
+      }
+
       const sendTurn = async (turn: SendTurnInput) => {
         const { threadId } = turn;
         if (active.has(threadId)) throw new Error("a turn is already running on this thread");
@@ -155,6 +240,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
             effort: turn.effort,
           }) ?? []),
         ];
+        widenPath();
         const child = spawn(config.cli, argv, {
           cwd: turn.cwd ?? homedir(),
           env: childEnv(turn.env),
@@ -162,27 +248,8 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
           detached: true,
         });
 
-        const state = { settled: false, text: "" };
+        const state = { settled: false, text: "", live: false };
         const asks = new Map<string, (behavior: string, message?: string) => void>();
-        let nextId = 1;
-        const rpcPending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
-
-        const write = (obj: unknown) => {
-          try {
-            child.stdin.write(JSON.stringify(obj) + "\n");
-          } catch {
-            /* the child died; close() will settle the turn */
-          }
-          appendNative(threadId, { dir: "out", source: `${spec.kind}.acp`, msg: obj });
-        };
-        const request = (method: string, params: unknown) =>
-          new Promise<any>((resolve, reject) => {
-            const id = nextId++;
-            rpcPending.set(id, { resolve, reject });
-            write({ jsonrpc: "2.0", id, method, params });
-          });
-        const notify = (method: string, params: unknown) =>
-          write({ jsonrpc: "2.0", method, params });
 
         const stop = () => {
           try {
@@ -196,11 +263,24 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
           }
         };
 
+        const rpc = attachRpc({
+          stdin: child.stdin,
+          stdout: child.stdout,
+          onFrame: (msg, dir) => appendNative(threadId, { dir, source: `${spec.kind}.acp`, msg }),
+          onRequest: (msg) => {
+            if (msg.method === "session/request_permission") handlePermission(msg);
+            else rpc.replyError(msg.id, -32601, "not supported by this client");
+          },
+          onNotify: (msg) => {
+            if (msg.method === "session/update") handleUpdate(msg.params);
+          },
+        });
+
         // An interrupt goes through the protocol first, so the agent can
         // put its tools down properly. The kill is the backstop.
         let sessionId: string | null = null;
         const interrupt = () => {
-          if (sessionId) notify("session/cancel", { sessionId });
+          if (sessionId) rpc.notify("session/cancel", { sessionId });
           setTimeout(stop, 2_000).unref?.();
         };
 
@@ -208,8 +288,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
           if (state.settled) return;
           state.settled = true;
           for (const finish of [...asks.values()]) finish("deny", "Bloks: the turn ended");
-          for (const p of rpcPending.values()) p.reject(new Error("turn settled"));
-          rpcPending.clear();
+          rpc.failPending(new Error("turn settled"));
           active.delete(threadId);
           if (state.text.trim()) {
             emit({ ...base(threadId, turnId), type: "item.completed", itemType: "assistant_text", text: state.text });
@@ -219,7 +298,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
         };
 
         // ── agent asks the user for permission ──
-        const handlePermission = (msg: any) => {
+        function handlePermission(msg: any) {
           const params = msg.params ?? {};
           const options: any[] = Array.isArray(params.options) ? params.options : [];
           const pick = (kinds: string[]) => options.find((o) => kinds.includes(o?.kind))?.optionId;
@@ -227,7 +306,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
           const denyId = pick(["reject_once", "reject_always"]) ?? options[options.length - 1]?.optionId;
 
           if (config.fullAuto && allowId) {
-            return write({ jsonrpc: "2.0", id: msg.id, result: { outcome: { outcome: "selected", optionId: allowId } } });
+            return rpc.reply(msg.id, { outcome: { outcome: "selected", optionId: allowId } });
           }
 
           const requestId = newId();
@@ -243,13 +322,12 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
               ? options.find((o) => String(o?.name ?? "").toLowerCase() === message.trim().toLowerCase())
               : null;
             const optionId = named?.optionId ?? (behavior === "allow" ? allowId : denyId);
-            write({
-              jsonrpc: "2.0",
-              id: msg.id,
-              result: optionId
+            rpc.reply(
+              msg.id,
+              optionId
                 ? { outcome: { outcome: "selected", optionId } }
                 : { outcome: { outcome: "cancelled" } },
-            });
+            );
             const denied = !optionId || optionId === denyId;
             emit({
               ...base(threadId, turnId),
@@ -272,10 +350,14 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
             // the agent names its own choices, so use its words
             choices: options.map((o) => String(o?.name ?? "")).filter(Boolean).slice(0, 5),
           });
-        };
+        }
 
         // ── streaming updates ──
-        const handleUpdate = (params: any) => {
+        function handleUpdate(params: any) {
+          // session/load replays history as the same notifications a live
+          // turn uses. Until we have sent session/prompt, none of it is
+          // this turn's output.
+          if (!state.live) return;
           const update = params?.update ?? {};
           switch (update.sessionUpdate) {
             case "agent_message_chunk": {
@@ -310,39 +392,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
               break;
             }
           }
-        };
-
-        let buf = "";
-        child.stdout.on("data", (chunk) => {
-          buf += chunk;
-          let nl;
-          while ((nl = buf.indexOf("\n")) !== -1) {
-            const line = buf.slice(0, nl);
-            buf = buf.slice(nl + 1);
-            if (!line.trim()) continue;
-            let msg: any;
-            try {
-              msg = JSON.parse(line);
-            } catch {
-              continue; // a stray log line, not protocol
-            }
-            appendNative(threadId, { dir: "in", source: `${spec.kind}.acp`, msg });
-            if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
-              const pend = rpcPending.get(msg.id);
-              if (!pend) continue;
-              rpcPending.delete(msg.id);
-              if (msg.error) pend.reject(new Error(msg.error.message ?? JSON.stringify(msg.error)));
-              else pend.resolve(msg.result);
-            } else if (msg.id !== undefined && msg.method === "session/request_permission") {
-              handlePermission(msg);
-            } else if (msg.id !== undefined && msg.method) {
-              // fs/* and terminal/* only arrive if we claimed the capability
-              write({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "not supported by this client" } });
-            } else if (msg.method === "session/update") {
-              handleUpdate(msg.params);
-            }
-          }
-        });
+        }
 
         let stderr = "";
         child.stderr.on("data", (c) => {
@@ -377,13 +427,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
 
         (async () => {
           try {
-            await request("initialize", {
-              protocolVersion: PROTOCOL_VERSION,
-              // we do not lend the agent our filesystem or terminal; it has
-              // its own, and every borrowed capability is another way in
-              clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
-              clientInfo: { name: "bloks", version: "1" },
-            });
+            await rpc.request("initialize", CLIENT_HELLO);
 
             const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
             const cwd = turn.cwd ?? homedir();
@@ -409,30 +453,27 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
             let session: any = null;
             if (cursor) {
               try {
-                session = (await request("session/load", { cwd, mcpServers, sessionId: cursor })) ?? {};
+                session = (await rpc.request("session/load", { cwd, mcpServers, sessionId: cursor })) ?? {};
                 session.sessionId ??= cursor;
               } catch {
                 /* the agent forgot this session; start a new one below */
               }
             }
-            if (!session) session = await request("session/new", { cwd, mcpServers });
+            if (!session) session = await rpc.request("session/new", { cwd, mcpServers });
             sessionId = session?.sessionId ?? null;
             if (!sessionId) throw new Error(`${spec.name} did not open a session`);
 
             // the agent knows its own model list better than we do
-            const available: any[] = session?.models?.availableModels ?? [];
-            if (available.length) {
-              models.options = available.map((m) => ({
-                id: String(m.modelId),
-                label: String(m.name || m.modelId),
-              }));
-              models.default = String(session.models.currentModelId ?? models.options[0].id);
+            const catalog = catalogFromSession(session);
+            if (catalog) {
+              models.options = catalog.options;
+              models.default = catalog.default;
             }
-            if (turn.model && available.some((m) => String(m.modelId) === turn.model)) {
-              await request("session/set_model", { sessionId, modelId: turn.model }).catch(() => {});
+            if (turn.model && catalog?.options.some((m) => m.id === turn.model)) {
+              await rpc.request("session/set_model", { sessionId, modelId: turn.model }).catch(() => {});
             }
             if (config.fullAuto) {
-              await request("session/set_mode", { sessionId, modeId: "yolo" }).catch(() => {});
+              await rpc.request("session/set_mode", { sessionId, modeId: "yolo" }).catch(() => {});
             }
 
             emit({
@@ -442,7 +483,8 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
               model: turn.model ?? models.default,
             });
 
-            const result = await request("session/prompt", {
+            state.live = true;
+            const result = await rpc.request("session/prompt", {
               sessionId,
               prompt: [{ type: "text", text: turn.system ? `${turn.system}\n\n${turn.text}` : turn.text }],
             });
@@ -468,11 +510,14 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
       };
 
       const snapshot = async (): Promise<ProviderSnapshot> => {
-        const version = await new Promise<string | null>((resolve) => {
-          execFile(config.cli, ["--version"], { timeout: 8_000 }, (err, stdout) =>
-            resolve(err ? null : stdout.trim().split("\n").pop()!.trim()),
-          );
-        });
+        widenPath();
+        const version = spec.probePath
+          ? (onPath(config.cli) ? basename(config.cli) : null)
+          : await new Promise<string | null>((resolve) => {
+              execFile(config.cli, ["--version"], { timeout: 8_000 }, (err, stdout) =>
+                resolve(err ? null : stdout.trim().split("\n").pop()!.trim()),
+              );
+            });
         if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
         const hasKey = (spec.keyEnv ?? []).some((k) => input.environment[k] || process.env[k]);
         const signedIn = (spec.authFiles ?? []).some((f) => existsSync(join(homedir(), f)));
@@ -580,6 +625,26 @@ export const ACP_SPECS: readonly AcpSpec[] = [
         { id: "auto", label: "Auto" },
         { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
       ],
+    },
+  },
+  {
+    kind: "pi",
+    name: "Pi",
+    // pi-acp on PATH, not npx: --version starts an ACP session and hangs,
+    // so the install check is "is this name on PATH" after widenPath
+    command: "pi-acp",
+    args: [],
+    probePath: true,
+    // pi serves whatever providers its own settings connect, so the
+    // catalog is pi's, not ours to guess
+    probeModels: true,
+    install: "npm i -g --ignore-scripts @earendil-works/pi-coding-agent && npm i -g pi-acp",
+    signIn: "run `pi` (or `pi-acp --terminal-login`) and configure providers/login",
+    // credentials live in Pi; nothing of ours to pass
+    authFiles: [".pi/agent/auth.json"],
+    models: {
+      default: "auto",
+      options: [{ id: "auto", label: "Auto" }],
     },
   },
 ];

--- a/server/drivers/acp.ts
+++ b/server/drivers/acp.ts
@@ -218,12 +218,20 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
       // are probed once with a throwaway session, so the picker starts
       // with real models. A failed probe leaves the placeholder; the
       // first turn replaces it with what the agent serves.
+      let finishCatalog = () => {};
+      const catalogReady = spec.probeModels
+        ? new Promise<void>((resolve) => {
+            finishCatalog = resolve;
+          })
+        : undefined;
       if (spec.probeModels) {
         widenPath();
         void probeCatalog(spec, config.cli, childEnv()).then((catalog) => {
-          if (!catalog) return;
-          models.options = catalog.options;
-          models.default = catalog.default;
+          if (catalog) {
+            models.options = catalog.options;
+            models.default = catalog.default;
+          }
+          finishCatalog();
         });
       }
 
@@ -531,6 +539,7 @@ export function acpDriver(spec: AcpSpec): ProviderDriver<AcpConfig> {
         enabled: input.enabled,
         models,
         snapshot,
+        catalogReady,
         adapter: {
           provider: spec.kind,
           capabilities: { sessionModelSwitch: "in-session" },

--- a/server/harness/jsonrpc-stdio.ts
+++ b/server/harness/jsonrpc-stdio.ts
@@ -46,6 +46,10 @@ export function attachRpc(options: RpcOptions): RpcLink {
   const pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
   let nextId = 1;
 
+  // A closed pipe can emit EPIPE asynchronously, beyond write's try/catch.
+  // The owner handles the child's exit and settles pending requests.
+  options.stdin.on("error", () => {});
+
   const write = (frame: unknown) => {
     try {
       options.stdin.write(JSON.stringify(frame) + "\n");

--- a/server/index.ts
+++ b/server/index.ts
@@ -517,6 +517,12 @@ function broadcast(payload: unknown) {
   }
 }
 
+for (const inst of registry.instances()) {
+  void inst.catalogReady?.then(async () => {
+    broadcast({ kind: "instances", instances: await registry.describe() });
+  });
+}
+
 /** Whether a frame is worth waking a sleeping phone for. Deliberately
  * narrow: a turn finishing is not worth a buzz, a turn blocked on a
  * human is exactly what the phone exists for. */

--- a/server/path.ts
+++ b/server/path.ts
@@ -34,10 +34,11 @@ function candidateDirs(): string[] {
     ];
   }
 
-  const fixed = [
+  const dirs = [
     "/opt/homebrew/bin", // Apple Silicon brew
     "/usr/local/bin", // Intel brew, and half the installers ever written
     join(home, ".local", "bin"),
+    join(home, ".local", "share", "pnpm"),
     join(home, ".grok", "bin"), // the xAI installer’s private prefix
     join(home, ".npm-global", "bin"),
     join(home, "Library", "pnpm"),
@@ -50,12 +51,20 @@ function candidateDirs(): string[] {
   const nvmVersions = join(home, ".nvm", "versions", "node");
   try {
     const newest = readdirSync(nvmVersions).sort().at(-1);
-    if (newest) fixed.push(join(nvmVersions, newest, "bin"));
+    if (newest) dirs.push(join(nvmVersions, newest, "bin"));
   } catch {
     /* no nvm */
   }
 
-  return fixed;
+  const prefix = process.env.npm_config_prefix || process.env.PREFIX;
+  if (prefix) dirs.push(join(prefix, "bin"));
+
+  return dirs;
+}
+
+/** True when spawn(cli) would find something, given PATH as widenPath left it. */
+export function onPath(cli: string): boolean {
+  return (process.env.PATH ?? "").split(delimiter).some((dir) => dir && existsSync(join(dir, cli)));
 }
 
 /**

--- a/server/providers.ts
+++ b/server/providers.ts
@@ -329,4 +329,12 @@ export const CLI_PROVIDERS = [
     signInHint: "Connect a Gemini key below, or run gemini to sign in with Google",
     docsUrl: "https://geminicli.com/docs/",
   },
+  {
+    kind: "pi",
+    name: "Pi",
+    auth: "cli" as const,
+    keyHint: "Install with npm i -g --ignore-scripts @earendil-works/pi-coding-agent && npm i -g pi-acp",
+    signInHint: "Run pi (or pi-acp --terminal-login) and configure providers/login",
+    docsUrl: "https://pi.dev/docs/latest",
+  },
 ];

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -25,6 +25,16 @@ function modelLabel(instance: InstanceInfo | undefined, model: string): string {
 const byUsable = (a: InstanceInfo, b: InstanceInfo) =>
   Number(b.snapshot.state === "available") - Number(a.snapshot.state === "available");
 
+/** A selection that names no option this instance serves means "whatever
+ * the engine defaults to": Pi's catalog follows its own settings, and a
+ * bot carried over from before a catalog changed is the general case.
+ * The turn behaves that way already (no set_model, engine default), so
+ * the picker shows and ticks exactly that. */
+function effectiveModel(instance: InstanceInfo | undefined, model: string): string {
+  const isKnown = instance?.models.options.some((o) => o.id === model);
+  return isKnown ? model : (instance?.models.default ?? model);
+}
+
 export function ModelPicker({ bot, className }: { bot: Bot; className?: string }) {
   const { state, dispatch } = useStore();
   const [open, setOpen] = useState(false);
@@ -64,10 +74,10 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
           setOpen((o) => !o);
         }}
         className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-[12.5px] text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground active:scale-[0.98]"
-        title={active ? `${active.displayName} · ${modelLabel(active, selection.model)}` : selection.model}
+        title={active ? `${active.displayName} · ${modelLabel(active, effectiveModel(active, selection.model))}` : selection.model}
       >
         {active && <ProviderMark driverKind={active.driverKind} size={13} />}
-        <span className="max-w-[140px] truncate">{modelLabel(active, selection.model)}</span>
+        <span className="max-w-[140px] truncate">{modelLabel(active, effectiveModel(active, selection.model))}</span>
         <ChevronDown size={13} className="opacity-60" />
       </button>
 
@@ -127,7 +137,8 @@ export function ModelPicker({ bot, className }: { bot: Bot; className?: string }
                 </div>
                 {railInstance.models.options.map((option) => {
                   const current =
-                    selection.instanceId === railInstance.instanceId && selection.model === option.id;
+                    selection.instanceId === railInstance.instanceId &&
+                    effectiveModel(railInstance, selection.model) === option.id;
                   const disabled = railInstance.snapshot.state !== "available";
                   return (
                     <button

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -275,6 +275,13 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
       want: "Optional. Adds a second engine your agents can use.",
     },
     {
+      kind: "pi",
+      name: "Pi",
+      command: "npm i -g --ignore-scripts @earendil-works/pi-coding-agent && npm i -g pi-acp",
+      have: "Installed. Agents can run on Pi too.",
+      want: "Optional. Install Pi and pi-acp to add a tool-running engine.",
+    },
+    {
       kind: "antigravity",
       name: "Antigravity",
       command: "curl -fsSL https://antigravity.google/cli/install.sh | bash",

--- a/src/components/ProviderIcons.tsx
+++ b/src/components/ProviderIcons.tsx
@@ -159,6 +159,22 @@ function LetterMark({ letter, tone, size = 16, className }: IconProps & { letter
   );
 }
 
+/** Pi. Their wordmark, on the dark tile the press kit shows it on,
+ * because the white paths vanish on a light rail. */
+export function PiMark({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 800 800" className={cn(className)}>
+      <rect width="800" height="800" rx="150" fill="#09090b" />
+      <path
+        fill="#fff"
+        fillRule="evenodd"
+        d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+      />
+      <path fill="#fff" d="M517.36 400H634.72V634.72H517.36Z" />
+    </svg>
+  );
+}
+
 const LETTERED: Record<string, { letter: string; tone: string }> = {
   deepseek: { letter: "D", tone: "#4d6bfe" },
   mistral: { letter: "M", tone: "#fa520f" },
@@ -189,6 +205,8 @@ export function ProviderMark({ driverKind, size, className }: IconProps & { driv
       return <LlamaMark size={size} className={className} />;
     case "openrouter":
       return <RouterMark size={size} className={className} />;
+    case "pi":
+      return <PiMark size={size} className={className} />;
   }
   const lettered = LETTERED[driverKind];
   if (lettered) return <LetterMark {...lettered} size={size} className={className} />;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -477,6 +477,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
             .then(({ instances }) => rawDispatch({ type: "instances", instances }))
             .catch(() => {});
           break;
+        case "instances":
+          if (Array.isArray(frame.instances)) rawDispatch({ type: "instances", instances: frame.instances });
+          break;
         case "bot.deleted":
           rawDispatch({ type: "deleteBot", botId: frame.botId });
           break;

--- a/test/acp-catalog.test.ts
+++ b/test/acp-catalog.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { test } from "node:test";
+
+import { instanceConfigs } from "../server/config.ts";
+import { ACP_SPECS, acpDriver } from "../server/drivers/acp.ts";
+import { BUILT_IN_DRIVERS } from "../server/drivers/builtIn.ts";
+import { onPath, widenPath } from "../server/path.ts";
+import { CLI_PROVIDERS } from "../server/providers.ts";
+import { startHarness } from "./helpers/server.ts";
+
+test("Pi is a catalogued ACP engine", () => {
+    const spec = ACP_SPECS.find((s) => s.kind === "pi");
+    assert.ok(spec, "kind pi belongs in ACP_SPECS");
+    assert.equal(spec?.command, "pi-acp");
+    assert.deepEqual(spec?.args, []);
+    assert.equal(spec?.probePath, true, "pi-acp --version starts a session");
+    assert.equal(spec?.probeModels, true, "pi's catalog follows its own settings, so it is probed");
+    assert.ok(CLI_PROVIDERS.some((p) => p.kind === "pi"), "kind pi belongs in CLI_PROVIDERS");
+    assert.ok(
+        BUILT_IN_DRIVERS.some((d) => d.driverKind === "pi"),
+        "kind pi is registered via acpDriver",
+    );
+});
+
+test("the default fleet creates a Pi instance, even if config already has others", () => {
+    assert.ok(Object.values(instanceConfigs({})).some((e) => e.driver === "pi"));
+    const saved = instanceConfigs({ instances: { claude: { driver: "claudeAgent" } } });
+    assert.ok(
+        Object.values(saved).some((e) => e.driver === "pi"),
+        "a saved instances map written before Pi existed must still probe it",
+    );
+});
+
+test("widenPath puts a well-known global bin on PATH when PATH is empty", () => {
+    const home = mkdtempSync(join(tmpdir(), "bloks-pi-path-"));
+    const bin = join(home, ".local", "bin");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, "pi-acp"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const prevHome = process.env.HOME;
+    const prevPath = process.env.PATH;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.PATH = "/nonexistent";
+    try {
+        widenPath();
+        assert.ok(process.env.PATH?.split(delimiter).includes(bin));
+        assert.equal(onPath("pi-acp"), true);
+    } finally {
+        process.env.HOME = prevHome;
+        process.env.USERPROFILE = prevProfile;
+        process.env.PATH = prevPath;
+    }
+});
+
+async function withPiHome(script: string, fn: () => Promise<void>) {
+    const home = mkdtempSync(join(tmpdir(), "bloks-pi-"));
+    const bin = join(home, ".local", "bin");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, "pi-acp"), script.endsWith("\n") ? script : script + "\n", { mode: 0o755 });
+
+    const prevHome = process.env.HOME;
+    const prevPath = process.env.PATH;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.PATH = dirname(process.execPath) + delimiter + "/nonexistent";
+    widenPath();
+    try {
+        await fn();
+    } finally {
+        process.env.HOME = prevHome;
+        process.env.USERPROFILE = prevProfile;
+        process.env.PATH = prevPath;
+    }
+}
+
+const PLACEHOLDER = { default: "auto", options: [{ id: "auto", label: "Auto" }] };
+
+async function createPi() {
+    const spec = ACP_SPECS.find((s) => s.kind === "pi")!;
+    return acpDriver(spec).create({
+        instanceId: "pi",
+        displayName: "Pi",
+        enabled: true,
+        config: { cli: "pi-acp", fullAuto: false },
+        environment: {},
+    });
+}
+
+async function waitUntil(pred: () => boolean) {
+    for (let i = 0; i < 50; i++) {
+        if (pred()) return;
+        await new Promise((r) => setTimeout(r, 100));
+    }
+}
+
+test("Pi's catalog is probed with a throwaway session, before any turn", async () => {
+    // Enough ACP to answer the two probe questions: initialize, then
+    // session/new carrying the catalog pi would serve.
+    const fake = [
+        "#!/usr/bin/env node",
+        'const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");',
+        'require("node:readline").createInterface({ input: process.stdin }).on("line", (line) => {',
+        "  let msg; try { msg = JSON.parse(line); } catch { return; }",
+        '  if (msg.method === "initialize") reply(msg.id, { protocolVersion: 1, agentCapabilities: {} });',
+        '  else if (msg.method === "session/new")',
+        '    reply(msg.id, { sessionId: "probe", models: { availableModels: [',
+        '      { modelId: "vendor/model-a", name: "Model A" },',
+        '      { modelId: "vendor/model-b", name: "Model B" },',
+        '    ], currentModelId: "vendor/model-a" } });',
+        "});",
+    ].join("\n");
+
+    await withPiHome(fake, async () => {
+        const inst = await createPi();
+        await waitUntil(() => inst.models.options.some((m) => m.id === "vendor/model-a"));
+        assert.deepEqual(inst.models, {
+            default: "vendor/model-a",
+            options: [
+                { id: "vendor/model-a", label: "Model A" },
+                { id: "vendor/model-b", label: "Model B" },
+            ],
+        });
+        await inst.dispose();
+    });
+});
+
+test("the catalog probe waits for initialize before opening a session", async () => {
+    // A pipelined write would deliver session/new while initialize is still
+    // pending; this agent answers that too-soon request with an empty catalog.
+    const fake = [
+        "#!/usr/bin/env node",
+        'const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");',
+        "let ready = false;",
+        'require("node:readline").createInterface({ input: process.stdin }).on("line", (line) => {',
+        "  let msg; try { msg = JSON.parse(line); } catch { return; }",
+        '  if (msg.method === "initialize") {',
+        "    setTimeout(() => { ready = true; reply(msg.id, { protocolVersion: 1, agentCapabilities: {} }); }, 50);",
+        '  } else if (msg.method === "session/new") {',
+        "    reply(msg.id, ready",
+        '      ? { sessionId: "probe", models: { availableModels: [{ modelId: "vendor/late", name: "Late" }], currentModelId: "vendor/late" } }',
+        '      : { sessionId: "too-soon", models: { availableModels: [] } });',
+        "  }",
+        "});",
+    ].join("\n");
+
+    await withPiHome(fake, async () => {
+        const inst = await createPi();
+        await waitUntil(() => inst.models.options.some((m) => m.id === "vendor/late"));
+        assert.deepEqual(inst.models, {
+            default: "vendor/late",
+            options: [{ id: "vendor/late", label: "Late" }],
+        });
+        await inst.dispose();
+    });
+});
+
+test("a failed catalog probe leaves the placeholder", async () => {
+    await withPiHome("#!/bin/sh\nexit 1\n", async () => {
+        const inst = await createPi();
+        await new Promise((r) => setTimeout(r, 300));
+        assert.deepEqual(inst.models, PLACEHOLDER);
+        await inst.dispose();
+    });
+});
+
+test("session/load history replay is not folded into the next turn", async () => {
+    // pi-acp (and the ACP spec) replay the whole conversation as
+    // session/update during session/load. Those frames must not land in
+    // this turn's assistant message; Bloks already has the transcript.
+    const fake = [
+        "#!/usr/bin/env node",
+        "const say = (obj) => process.stdout.write(JSON.stringify(obj) + '\\n');",
+        "const reply = (id, result) => say({ jsonrpc: '2.0', id, result });",
+        "const chunk = (text) => say({ jsonrpc: '2.0', method: 'session/update', params: {",
+        "  sessionId: 's1',",
+        "  update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } },",
+        "} });",
+        "require('node:readline').createInterface({ input: process.stdin }).on('line', (line) => {",
+        "  let msg; try { msg = JSON.parse(line); } catch { return; }",
+        "  if (msg.method === 'initialize') reply(msg.id, { protocolVersion: 1, agentCapabilities: {} });",
+        "  else if (msg.method === 'session/new') reply(msg.id, { sessionId: 's1' });",
+        "  else if (msg.method === 'session/load') { chunk('OLD'); reply(msg.id, { sessionId: 's1' }); }",
+        "  else if (msg.method === 'session/prompt') { chunk('NEW'); reply(msg.id, { stopReason: 'end_turn' }); }",
+        "});",
+    ].join("\n");
+
+    await withPiHome(fake, async () => {
+        const inst = await createPi();
+        const events: { type: string; delta?: string; text?: string; itemType?: string }[] = [];
+        inst.adapter.onEvent((e) => events.push(e as (typeof events)[number]));
+        await inst.adapter.sendTurn({ threadId: "t1", text: "again", resumeCursor: "s1" });
+        await waitUntil(() => events.some((e) => e.type === "turn.completed"));
+        const deltas = events.filter((e) => e.type === "content.delta").map((e) => e.delta).join("");
+        const completed = events.find((e) => e.type === "item.completed" && e.itemType === "assistant_text");
+        assert.equal(deltas, "NEW", "replayed history must not stream as this turn");
+        assert.equal(completed?.text, "NEW");
+        await inst.dispose();
+    });
+});
+
+test("Pi's snapshot is available when pi-acp is installed off PATH", async () => {
+    const home = mkdtempSync(join(tmpdir(), "bloks-pi-snap-"));
+    const bin = join(home, ".local", "bin");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, "pi-acp"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const spec = ACP_SPECS.find((s) => s.kind === "pi")!;
+    const prevHome = process.env.HOME;
+    const prevPath = process.env.PATH;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.PATH = "/nonexistent";
+    widenPath();
+    try {
+        const inst = await acpDriver(spec).create({
+            instanceId: "pi",
+            displayName: "Pi",
+            enabled: true,
+            config: { cli: "pi-acp", fullAuto: false },
+            environment: {},
+        });
+        const snap = await inst.snapshot();
+        assert.equal(snap.state, "available");
+        assert.equal(snap.authenticated, false, "installed must not depend on auth");
+        await inst.dispose();
+    } finally {
+        process.env.HOME = prevHome;
+        process.env.USERPROFILE = prevProfile;
+        process.env.PATH = prevPath;
+    }
+});
+
+test("the harness reports Pi available when pi-acp lives in a global bin", async () => {
+    const h = await startHarness();
+    try {
+        const bin = join(h.home, ".local", "bin");
+        mkdirSync(bin, { recursive: true });
+        writeFileSync(join(bin, "pi-acp"), "#!/bin/sh\n", { mode: 0o755 });
+
+        const { instances } = await h.json("/api/instances");
+        const pi = instances.find((i: { driverKind: string }) => i.driverKind === "pi");
+        assert.ok(pi, "default fleet must create a pi instance");
+        assert.equal(pi.snapshot.state, "available");
+        assert.equal(pi.snapshot.authenticated, false);
+
+        const { providers } = await h.json("/api/providers");
+        const row = providers.find((p: { kind: string }) => p.kind === "pi");
+        assert.equal(row?.connected, true);
+    } finally {
+        await h.stop();
+    }
+});

--- a/test/agent-cli.test.ts
+++ b/test/agent-cli.test.ts
@@ -251,7 +251,7 @@ describe("the credential itself", () => {
 
 describe("who gets a credential at all", () => {
   test("only an engine that runs a process, because that is how it is handed over", () => {
-    for (const kind of ["claudeAgent", "codex", "antigravity", "opencode", "grokCli"]) {
+    for (const kind of ["claudeAgent", "codex", "antigravity", "opencode", "grokCli", "pi"]) {
       assert.equal(runsAProcess(kind), true, kind);
     }
     // an HTTP engine has nowhere to put it and no shell to spend it from

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -185,6 +185,8 @@ describe("the engine catalog", () => {
     assert.equal(byKind.grokCli.auth, "cli");
     assert.equal(byKind.antigravity.auth, "cli");
     assert.equal(byKind.opencode.auth, "cli");
+    assert.equal(byKind.pi.auth, "cli");
+    assert.equal(byKind.pi.agentic, true, "Pi runs tools through pi-acp");
   });
 
   test("nothing is connected in a fresh install", async () => {

--- a/test/jsonrpc-stdio.test.ts
+++ b/test/jsonrpc-stdio.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { PassThrough, Writable } from "node:stream";
+import { test } from "node:test";
+
+import { attachRpc } from "../server/harness/jsonrpc-stdio.ts";
+
+test("an asynchronous broken pipe does not crash the RPC transport", async () => {
+  const brokenPipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+  const stdin = new Writable({
+    write(_chunk, _encoding, callback) {
+      // A child can exit before initialize is written. Pipe errors arrive
+      // after write returns, so a synchronous try/catch cannot catch them.
+      process.nextTick(callback, brokenPipe);
+    },
+  });
+  const stdout = new PassThrough();
+  const rpc = attachRpc({ stdin, stdout, onRequest() {}, onNotify() {} });
+  const closed = new Promise<void>((resolve) => stdin.once("close", resolve));
+  const pending = rpc.request("initialize");
+  const rejected = assert.rejects(pending, /child exited/);
+
+  await closed;
+  assert.equal(stdin.errored, brokenPipe);
+  // The owner still settles requests when it observes the child's exit.
+  rpc.failPending(new Error("child exited"));
+  await rejected;
+  stdout.destroy();
+});


### PR DESCRIPTION
Pi is another engine an agent can run on in Bloks, the same way Claude Code, Codex and Gemini CLI already can: tools, files, and approval cards.

It is not a new driver. Pi speaks the Agent Client Protocol, so it is a catalog entry on the existing ACP driver. Bloks launches `pi-acp` over stdio, the same as OpenCode or Gemini CLI in ACP mode.

`pi-acp --version` starts a session and hangs, so install is whether `pi-acp` is on PATH after widenPath. The model list comes from a throwaway session, because the catalog is whatever providers Pi itself has connected.

session/load replays the whole conversation as session/update. Bloks already has that transcript, so those frames are ignored until session/prompt. Otherwise each send reprints history into the new reply.